### PR TITLE
Add new detection method (non-system library detection)

### DIFF
--- a/app/src/main/cpp/solist.cpp
+++ b/app/src/main/cpp/solist.cpp
@@ -32,7 +32,7 @@ SoInfo *DetectInjection() {
     }
 
     if (iter->get_name() == NULL &&
-        strstr(iter->get_path(), "/system/bin/app_proces")) {
+        strstr(iter->get_path(), "/system/bin/app_process")) {
       app_process_loaded = true;
       // /system/bin/app_process64 maybe set null name
       LOGD("Skip %s, gap size", iter, iter->get_path());

--- a/app/src/main/cpp/solist.cpp
+++ b/app/src/main/cpp/solist.cpp
@@ -39,6 +39,16 @@ SoInfo *DetectInjection() {
       continue;
     }
 
+    if (
+      strncmp(iter->get_path(), "/system/", strlen("/system/")) != 0 &&
+      strncmp(iter->get_path(), "/apex/", strlen("/apex/")) != 0 &&
+      strcmp(iter->get_path(), "[vdso]") != 0
+    ) {
+      LOGW("Found suspicious library: 0x%lx (%s)", iter, iter->get_path());
+
+      return iter;
+    }
+
     if (iter - prev != gap && gap_repeated < 1) {
       gap = iter - prev;
       gap_repeated = 0;


### PR DESCRIPTION
Demo has been detecting whether or not a library in SoInfo has:
- Have its name NULLd or empty
- Was dropped, leaving a gap, which it detects
- Libraries before some events

However, those are still bypassable if we keep a suspicious library there. This can be detected by seeing if the path of the shared library is not in the common/normal system lib paths. This still can be bypassed by, if possible, moving libzygisk.so to those paths, but it's extremely dirty and still can be detected by comparing the name (and even if name spoofed, by content).