### PR TITLE
Detect mount inconsistency

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -29,7 +29,7 @@ set(CMAKE_CXX_STANDARD 20)
 # used in the AndroidManifest.xml file.
 add_library(${CMAKE_PROJECT_NAME} SHARED
         # List C/C++ source files with relative paths to this CMakeLists.txt.
-        atexit.cpp elf_util.cpp native-lib.cpp smap.cpp solist.cpp vmap.cpp)
+        atexit.cpp elf_util.cpp native-lib.cpp smap.cpp solist.cpp statfs.cpp vmap.cpp)
 
 target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC include)
 # Specifies libraries CMake should link to your target library. You

--- a/app/src/main/cpp/include/statfs.hpp
+++ b/app/src/main/cpp/include/statfs.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <string>
+
+std::string get_filesystem_type(const std::string &path);

--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -2,6 +2,7 @@
 #include "logging.h"
 #include "smap.h"
 #include "solist.hpp"
+#include "statfs.hpp"
 #include "vmap.hpp"
 #include <format>
 #include <jni.h>
@@ -14,6 +15,8 @@ Java_org_matrix_demo_MainActivity_stringFromJNI(JNIEnv *env,
   std::string solist_detection = "No injection found using solist";
   std::string vmap_detection = "No injection found using vitrual map";
   std::string counter_detection = "No injection found using module counter";
+  std::string system_mount_detection =
+      "No traces found for /system re-mounting";
   SoList::SoInfo *abnormal_soinfo = SoList::DetectInjection();
   VirtualMap::MapInfo *abnormal_vmap = VirtualMap::DetectInjection();
   size_t module_injected = SoList::DetectModules();
@@ -22,6 +25,7 @@ Java_org_matrix_demo_MainActivity_stringFromJNI(JNIEnv *env,
   if (g_array != nullptr) {
     LOGD("g_array status: %s", g_array->format_state_string().c_str());
   }
+  auto mount_type = get_filesystem_type("/proc/self/exe");
 
   if (abnormal_soinfo != nullptr) {
     solist_detection =
@@ -42,7 +46,12 @@ Java_org_matrix_demo_MainActivity_stringFromJNI(JNIEnv *env,
         "Module counter: {} shared libraries unloaded", module_injected);
   }
 
-  return env->NewStringUTF(
-      (solist_detection + "\n" + vmap_detection + "\n" + counter_detection)
-          .c_str());
+  if (mount_type != "EXT4") {
+    system_mount_detection =
+        std::format("/system/bin was mounted with type {}", mount_type);
+  }
+
+  return env->NewStringUTF((solist_detection + "\n" + vmap_detection + "\n" +
+                            counter_detection + "\n" + system_mount_detection)
+                               .c_str());
 }

--- a/app/src/main/cpp/statfs.cpp
+++ b/app/src/main/cpp/statfs.cpp
@@ -1,0 +1,56 @@
+#include "statfs.hpp"
+
+#include <cerrno>  // For errno
+#include <cstring> // For strerror
+#include <iomanip> // For std::hex and std::setw
+#include <iostream>
+#include <linux/magic.h> // Provides standard magic number definitions
+#include <sstream>       // For converting hex
+#include <sys/vfs.h>     // For statfs
+
+/**
+ * @brief Get the filesystem type for a given mount path.
+ *
+ * This function uses statfs() to retrieve the filesystem magic number
+ * and returns a human-readable string representation (e.g., "EXT4",
+ * "OverlayFS"). If the filesystem type is unknown, it returns the magic number
+ * in hex.
+ *
+ * @param path The mount path to check (e.g., "/system").
+ * @return A std::string containing the name of the filesystem or an error
+ * message.
+ */
+std::string get_filesystem_type(const std::string &path) {
+  struct statfs statfs_buf;
+
+  // Call statfs to get filesystem statistics
+  if (statfs(path.c_str(), &statfs_buf) != 0) {
+    // If statfs fails, return an error string with the reason
+    return "Error checking filesystem: " + std::string(strerror(errno));
+  }
+
+  // Check the f_type field against known magic numbers
+  switch (statfs_buf.f_type) {
+  case EXT4_SUPER_MAGIC:
+    return "EXT4";
+  case OVERLAYFS_SUPER_MAGIC:
+    return "OverlayFS";
+  case F2FS_SUPER_MAGIC:
+    return "F2FS";
+  case TMPFS_MAGIC:
+    return "tmpfs";
+  case PROC_SUPER_MAGIC:
+    return "procfs";
+  // case SQUASHFS_MAGIC:
+  //     return "SquashFS";
+  // case EROFS_SUPER_MAGIC_V1:
+  //     return "EROFS";
+  default: {
+    // If the type is unknown, format it as a hex string for logging
+    std::stringstream ss;
+    ss << "Unknown (0x" << std::hex << std::setw(8) << std::setfill('0')
+       << statfs_buf.f_type << ")";
+    return ss.str();
+  }
+  }
+}


### PR DESCRIPTION
If the `/system` directory is mounted by KernelSU as overlayfs, then many detectors can still detect the mounting trace even the target is correctly unmounted.

In Holmes V1.5.1, it is shown as `Inconsistent Mount`. In Hunter 6.41, it is shown as
```
found OVERLAYFS_SUPER_MAGIC, but no overlayfs mount found
```

I am going to figure out this detection. However, no luck via scanning /proc/self/fd yet.